### PR TITLE
Switch to rattler-build to fix Windows MemoryError

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,6 +2,7 @@ build_platform:
   osx_arm64: osx_64
 conda_build:
   pkg_format: '2'
+conda_build_tool: rattler-build
 conda_forge_output_validation: true
 github:
   branch_name: main

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,7 +2,6 @@ build_platform:
   osx_arm64: osx_64
 conda_build:
   pkg_format: '2'
-conda_build_tool: rattler-build
 conda_forge_output_validation: true
 github:
   branch_name: main

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,7 @@
 @echo off
 :: Limit parallel builds to prevent memory exhaustion on Windows CI
-:: CGAL template-heavy C++ compilation uses ~2GB per thread
-set CMAKE_BUILD_PARALLEL_LEVEL=2
+:: CGAL template-heavy C++ compilation uses ~4GB per thread
+set CMAKE_BUILD_PARALLEL_LEVEL=1
 
 %PYTHON% -m pip install . -v
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,9 @@
+@echo off
+set CMAKE_BUILD_PARALLEL_LEVEL=%CPU_COUNT%
+
+%PYTHON% -m pip install . -v
+if errorlevel 1 exit 1
+
+:: Clean up build directory to reduce size before conda-build stats collection
+:: This prevents MemoryError in directory_size() on Windows
+if exist "%SRC_DIR%\build" rd /s /q "%SRC_DIR%\build"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,9 +1,10 @@
 @echo off
-set CMAKE_BUILD_PARALLEL_LEVEL=%CPU_COUNT%
+:: Limit parallel builds to prevent memory exhaustion on Windows CI
+:: CGAL template-heavy C++ compilation uses ~2GB per thread
+set CMAKE_BUILD_PARALLEL_LEVEL=2
 
 %PYTHON% -m pip install . -v
 if errorlevel 1 exit 1
 
 :: Clean up build directory to reduce size before conda-build stats collection
-:: This prevents MemoryError in directory_size() on Windows
 if exist "%SRC_DIR%\build" rd /s /q "%SRC_DIR%\build"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ex
+
+export CMAKE_BUILD_PARALLEL_LEVEL=${CPU_COUNT}
+
+${PYTHON} -m pip install . -v
+
+# Clean up build directory to reduce size
+rm -rf "${SRC_DIR}/build"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,6 @@ source:
 
 build:
   number: 1
-  script:
-    - export CMAKE_BUILD_PARALLEL_LEVEL=${CPU_COUNT}  # [win]
-    - {{ PYTHON }} -m pip install . -v
 
 requirements:
   build:


### PR DESCRIPTION
conda build tool: rattler-build . due to windows build error for the memory issues.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

